### PR TITLE
Enable package installation using setup.py

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Getting Python
 --------------
 tetra3 is written for Python 3.7+ (and therefore runs on almost any platform) and should work with
 most modern Python 3 installations. There are many ways to get Python on your system. Most easily,
-by going to `the python webiste<https://www.python.org/>`_ and selecting your platform. However,
+by going to `the python webiste <https://www.python.org/>`_ and selecting your platform. However,
 the preferred
 method is by `downloading Miniconda for Python 3+ 
 <https://docs.conda.io/en/latest/miniconda.html>`_. If you are on Windows you will be given the
@@ -84,17 +84,24 @@ a free book on Git, and introductory videos is a good place to start.
 
 Installing tetra3
 -----------------
-To install the requirements open a terminal/CMD window in the tetra3 directory and run::
+To install the package, open a terminal/CMD window in the tetra3 directory and run::
 
-    pip install -r requirements.txt
+    pip install .
     
-to install all requirements. Test that everything works by running an example::
+to install the dependencies and make the tetra3 module accessible from anywhere. Test that
+everything works by running an example::
 
     cd examples
     python test_tetra3.py
     
 which should print out the solutions for the included test images.
-    
+
+Alternatively, the package can be installed directly from GitHub using pip::
+
+    pip install git+https://github.com/esa/tetra3.git
+
+Doing it this way means you can skip the steps outlined in :ref:`Getting tetra3`.
+
 If problems arise
 -----------------
 Please get in touch by `filing an issue <https://github.com/esa/tetra3/issues>`_.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+with open("./README.rst", "r") as f:
+    readme = f.read()
+
+with open("./requirements.txt", "r") as f:
+    requirements = [req.strip().replace(" ", "") for req in f]
+
+if __name__ == "__main__":
+    setup(name="tetra3", packages=["tetra3"], package_dir={"tetra3": "."},
+          description="A fast lost-in-space plate solver for star trackers.",
+          long_description=readme, long_description_content_type="text/x-rst",
+          url="https://github.com/esa/tetra3",
+          download_url="https://github.com/esa/tetra3/archive/refs/heads/master.zip",
+          project_urls={"docs": "https://tetra3.readthedocs.io/en/latest/"},
+          license="Apache-2.0", install_requires=requirements)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open("./requirements.txt", "r") as f:
 
 if __name__ == "__main__":
     setup(name="tetra3", packages=["tetra3"], package_dir={"tetra3": "."},
+          package_data={"": ["default_database.npz"]},
           description="A fast lost-in-space plate solver for star trackers.",
           long_description=readme, long_description_content_type="text/x-rst",
           url="https://github.com/esa/tetra3",


### PR DESCRIPTION
Currently the "package"  cannot really be installed as a true Python package, and users are expected to simply place the tetra3.py source file in whatever project they are using it in. This runs counter to the typical Python package management philosophy/workflow, and impedes ease of use.

This pull request adds a setup.py file to enable package installation using pip with the syntax `python setup.py install` (or alternatively, `pip install .`) so that users can use then do `from tetra3 import Tetra3` (or similar) from anywhere. An added benefit of this is that pip also supports installation from remote Git repositories, which means users can simply do `pip install git+https://github.com/esa/tetra3.git` once this setup.py exists, without having to separately download the source zip or clone the repository.

This installation method also means that manual dependency installation (`pip install -r requirements.txt`) ahead of time is no longer necessary, as the requirements.txt file is automatically read by setup.py and used during the installation process.

A few lines on the installation.rst documentation page have also been tweaked to provide instructions using this new method.

---

Edit: I actually hadn't noticed it when I made these changes, but coincidentally it looks like this PR will resolve #14. :slightly_smiling_face: