### PR TITLE
Modify example script so it is doesn't depend on a specific CWD

### DIFF
--- a/examples/test_tetra3.py
+++ b/examples/test_tetra3.py
@@ -4,16 +4,18 @@ This example loads the tetra3 default database and solves for every image in the
 Note: Requires PIL (pip install Pillow)
 """
 import sys
-sys.path.append('..')
-from tetra3 import Tetra3
 from PIL import Image
 from pathlib import Path
+EXAMPLES_DIR = Path(__file__).parent
+TETRA3_DIR = EXAMPLES_DIR.parent
+sys.path.append(str(TETRA3_DIR))
+from tetra3 import Tetra3
 
 # Create instance and load default_database (built with max_fov=12 and the rest as default)
 t3 = Tetra3('default_database')
 
 # Path where images are
-path = Path('../test_data/')
+path = TETRA3_DIR / "test_data"
 for impath in path.glob('*.tiff'):
     print('Solving for image at: ' + str(impath))
     with Image.open(str(impath)) as img:


### PR DESCRIPTION
Currently, running test_tetra3.py relies on the current working directory (CWD) being tetra3/examples/, and if it is run from anywhere else (including just tetra3/), it fails. This is easily fixed (e.g. so that `python examples/test_tetra3.py` from the top-level directory works) by making the paths relative to the absolute path of the script file itself, which can be accessed using the `__file__` special variable.

This is a very minor change and should be entirely transparent to users, with the old method of `cd examples ; python test_tetra3.py` working just as it always has.